### PR TITLE
Fix: 審査画面で改めてユーザーが作成されないように修正

### DIFF
--- a/app/controllers/api/v1/judgements_controller.rb
+++ b/app/controllers/api/v1/judgements_controller.rb
@@ -1,5 +1,6 @@
 class Api::V1::JudgementsController < ApplicationController
   before_action :set_judgement, only: %i[update destroy]
+  skip_before_action :set_judge
 
   def create
     judgements = judgements_params.to_h


### PR DESCRIPTION
## 概要
- judgementsコントローラでset_judgeをスキップ設定